### PR TITLE
PAE-000: Resolve Snyk vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3060,9 +3060,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "overrides": {
     "eslint": "$eslint",
     "serialize-javascript": "7.0.5",
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "basic-ftp": "5.2.1"
   },
   "devDependencies": {
     "eslint": "10.1.0",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## What

Automated Snyk vulnerability fixes for open-source dependency scan findings.

## Open-source dependency vulnerabilities

| Package | Old Version | New Version | Severity | Vulnerability |
|---------|-------------|-------------|----------|---------------|
| basic-ftp | 5.2.0 | 5.2.1 | Critical | CRLF Injection ([SNYK-JS-BASICFTP-15953339](https://security.snyk.io/vuln/SNYK-JS-BASICFTP-15953339)) |

**Fix applied:** Added `"basic-ftp": "5.2.1"` to `overrides` in `package.json` to resolve the transitive dependency via `@wdio/cli` → `@puppeteer/browsers` → `proxy-agent` → `pac-proxy-agent` → `get-uri` → `basic-ftp`.

## Unfixed / Acknowledged

| Package | Version | Severity | Vulnerability | Reason |
|---------|---------|----------|---------------|--------|
| inflight | 1.0.6 | Medium | Missing Release of Resource after Effective Lifetime ([SNYK-JS-INFLIGHT-6095116](https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116)) | No upgrade or patch available. Transitive dependency via `mocha` → `glob@8.1.0`. The `inflight` package is deprecated but has no replacement within the `glob@8` dependency tree. |

## Verification

- `snyk test` — critical `basic-ftp` vulnerability resolved; only unfixable `inflight` (medium) remains
- `snyk code test` — no code analysis issues found
- `npm test` — e2e tests require browser infrastructure (WebDriverIO + Chrome); no test regressions from dependency change