### PR TITLE
PAE-0000: bump axios and basic-ftp to clear Snyk vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2932,14 +2932,23 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -3060,9 +3069,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "eslint": "$eslint",
     "serialize-javascript": "7.0.5",
     "lodash": "4.18.1",
-    "basic-ftp": "5.2.1"
+    "basic-ftp": "5.2.2",
+    "axios": "1.15.0"
   },
   "devDependencies": {
     "eslint": "10.1.0",


### PR DESCRIPTION
Ticket: [PAE-0000](https://eaflood.atlassian.net/browse/PAE-0000)
## Summary

- Clears three transitive Snyk findings on `main` by overriding `axios` and bumping `basic-ftp`.
- `axios@1.13.5` (Critical Confused Deputy + High HTTP Response Splitting) → `1.15.0`.
- `basic-ftp@5.2.1` (High CRLF Injection) → `5.2.2` (Critical CRLF was already resolved at 5.2.1).
- Only remaining Snyk finding after this change is `inflight@1.0.6` (Medium), which has no upstream fix.

## Changes

- `package.json` — add `axios: 1.15.0` override, bump `basic-ftp` override `5.2.1` → `5.2.2`.
- `package-lock.json` — regenerated via `npm install` to reflect the overrides.
