### PR TITLE
PAE-1330: Remove FEATURE_FLAG_OVERSEAS_SITES from compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -105,7 +105,6 @@ services:
       ENTRA_CLIENT_SECRET: test
       OIDC_WELL_KNOWN_CONFIGURATION_URL: http://epr-re-ex-entra-stub:3010/.well-known/openid-configuration
       USE_SINGLE_INSTANCE_CACHE: true
-      FEATURE_FLAG_OVERSEAS_SITES: true
       CDP_UPLOADER_URL: http://localhost:7337
     depends_on:
       redis:
@@ -166,7 +165,6 @@ services:
       GOVUK_NOTIFY_API_KEY: fake-key-for-testing
       FEATURE_FLAG_SUMMARY_LOGS: true
       FEATURE_FLAG_DEV_ENDPOINTS: true
-      FEATURE_FLAG_OVERSEAS_SITES: true
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://epr-re-ex-entra-stub:3010/.well-known/openid-configuration
       ADMIN_UI_ENTRA_CLIENT_ID: clientId
       SERVICE_MAINTAINER_EMAILS: '["ea@test.gov.uk"]'


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

- Remove `FEATURE_FLAG_OVERSEAS_SITES` environment variable from both service blocks in `compose.yml`
- Flag has been enabled in production since 2026-03-25 and has been removed from the admin-frontend service code (PR #348, merged)

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ