### PR TITLE
PAE-1194: Add post-test org cleanup to prevent data pollution

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,36 @@
 #!/bin/sh
 
 echo "run_id: $RUN_ID"
+
+# Best-effort cleanup of every orgId the test suite created. Runs regardless
+# of pass/fail — we still want to delete data from failed runs. See PAE-1194.
+cleanup_created_orgs() {
+  id_file="test-artifacts/created-org-ids.txt"
+  if [ ! -s "$id_file" ]; then
+    echo "cleanup: no IDs to clean up"
+    return 0
+  fi
+  if [ -z "$ENVIRONMENT" ]; then
+    echo "cleanup: ENVIRONMENT not set; skipping"
+    return 0
+  fi
+  backend_url="https://epr-backend.${ENVIRONMENT}.cdp-int.defra.cloud"
+  total=$(wc -l < "$id_file" | tr -d ' ')
+  echo "cleanup: deleting $total orgs via $backend_url"
+  fail=0
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    status=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X DELETE "$backend_url/v1/dev/organisations/$id" || echo "000")
+    echo "  cleanup: $id -> $status"
+    [ "$status" = "200" ] || fail=$((fail + 1))
+  done < "$id_file"
+  echo "cleanup: complete. failures: $fail / $total"
+  return 0
+}
+
+trap 'cleanup_created_orgs' EXIT
+
 GREP='@smoketest' npm test
 
 npm run report:publish

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -5,6 +5,7 @@ import {
 } from '../support/generator.js'
 
 import { BaseAPI } from '../apis/base-api.js'
+import { trackCreatedOrgId } from './cleanup-tracker.js'
 import { expect } from '@wdio/globals'
 import { request } from 'undici'
 
@@ -93,6 +94,7 @@ export async function createLinkedOrganisation(dataRows) {
   const orgResponseData = await response.body.json()
 
   const orgId = orgResponseData?.orgId
+  trackCreatedOrgId(orgId)
   const refNo = orgResponseData?.referenceNumber
 
   for (const dataRow of dataRows) {

--- a/test/support/cleanup-tracker.js
+++ b/test/support/cleanup-tracker.js
@@ -1,0 +1,54 @@
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
+const cleanupFilePath = resolve(
+  process.cwd(),
+  'test-artifacts',
+  'created-org-ids.txt'
+)
+
+function ensureDir() {
+  const dir = dirname(cleanupFilePath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+/**
+ * Appends an orgId to the cleanup file. Called on every successful org creation
+ * so entrypoint.sh can delete them after the run.
+ *
+ * Uses appendFileSync because POSIX guarantees atomic writes for small payloads
+ * under PIPE_BUF (4096 bytes). A 6-digit orgId + newline is 7 bytes, so
+ * appends are safe even under concurrent workers.
+ *
+ * Swallows write errors — never fail a test because the tracker couldn't write.
+ */
+export function trackCreatedOrgId(orgId) {
+  if (!orgId) {
+    return
+  }
+  try {
+    ensureDir()
+    appendFileSync(cleanupFilePath, `${orgId}\n`)
+  } catch (err) {
+    console.warn(
+      `cleanup-tracker: failed to record orgId ${orgId}: ${err.message}`
+    )
+  }
+}
+
+/**
+ * Wipes the cleanup file at the start of a run. Prevents stale IDs from a
+ * previous local run appearing in the cleanup log.
+ */
+export function resetTracker() {
+  try {
+    ensureDir()
+    writeFileSync(cleanupFilePath, '')
+  } catch (err) {
+    console.warn(`cleanup-tracker: failed to reset tracker: ${err.message}`)
+  }
+}
+
+export { cleanupFilePath }

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { resetTracker } from './test/support/cleanup-tracker.js'
 
 const oneMinute = 60 * 1000
 
@@ -146,7 +147,9 @@ export const config = {
    * @param {Array.<String>} specs        List of spec file paths that are to be run
    * @param {object}         browser      instance of created browser/device session
    */
-  // before: function (capabilities, specs) {},
+  before: function (capabilities, specs) {
+    resetTracker()
+  },
   /**
    * Runs before a WebdriverIO command gets executed.
    * @param {string} commandName hook command name


### PR DESCRIPTION
Ticket: [PAE-1194](https://eaflood.atlassian.net/browse/PAE-1194)
## Summary

- Introduces `test/support/cleanup-tracker.js` (identical pattern to `epr-frontend-journey-tests` and `epr-backend-journey-tests`) that tracks org IDs created during the test run
- Calls `trackCreatedOrgId(orgId)` in `apicalls.js` immediately after a successful org creation so every created org is recorded
- Adds `resetTracker()` to the WDIO `before` hook in `wdio.conf.js` to clear stale IDs from previous local runs before each suite starts
- Adds `cleanup_created_orgs()` to `entrypoint.sh` with an EXIT trap so orgs are deleted via `DELETE /v1/dev/organisations/{id}` regardless of pass/fail; skips if `ENVIRONMENT` is not set (safety for local runs)

## Test plan

- [ ] Verify the branch runs cleanly in CI
- [ ] Confirm shared environment orgs are cleaned up after a test run by checking the cleanup log output

[PAE-1194]: https://eaflood.atlassian.net/browse/PAE-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ