### PR TITLE
PAE-1360: Drop env vars not read by any service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -113,7 +113,6 @@ services:
       PORT: 3002
       NODE_ENV: development
       REDIS_HOST: redis
-      LOCALSTACK_ENDPOINT: http://floci:4566
       EPR_BACKEND_URL: http://epr-backend:3001
       ENTRA_TENANT_ID: tenantId
       ENTRA_CLIENT_ID: clientId
@@ -175,7 +174,6 @@ services:
       APP_BASE_URL: http://epr-backend:3001
       PORT: 3001
       NODE_ENV: development
-      LOCALSTACK_ENDPOINT: http://floci:4566
       MONGO_URI: mongodb://mongodb:27017/
       GOVUK_NOTIFY_API_KEY: fake-key-for-testing
       FEATURE_FLAG_SUMMARY_LOGS: true
@@ -185,7 +183,6 @@ services:
       SERVICE_MAINTAINER_EMAILS: '["ea@test.gov.uk"]'
       CDP_UPLOADER_URL: http://cdp-uploader:7337
       SQS_ENDPOINT: http://floci:4566
-      COMMAND_QUEUE_SQS_ENDPOINT: http://floci:4566
     ports:
       - '3001:3001'
     healthcheck:

--- a/docker/config/defaults.env
+++ b/docker/config/defaults.env
@@ -7,7 +7,6 @@ REDIS_HOST=redis
 USE_SINGLE_INSTANCE_CACHE=true
 
 # Floci/AWS
-LOCALSTACK_URL=http://floci:4566
 SNS_ENDPOINT=http://floci:4566
 SQS_ENDPOINT=http://floci:4566
 S3_ENDPOINT=http://floci:4566


### PR DESCRIPTION
Ticket: [PAE-1360](https://eaflood.atlassian.net/browse/PAE-1360)

Follow-up to #152 (LocalStack to Floci migration). That PR faithfully carried forward four env vars whose values were updated from `localstack:4566` to `floci:4566`, but none of them are actually consumed by any service in the stack. This PR removes them.

## What changed

- **`docker/config/defaults.env`** — removed `LOCALSTACK_URL`. Neither `epr-re-ex-admin-frontend` nor `epr-backend` (the only services that load this file) reference this var in their application config.
- **`compose.yml` (`epr-re-ex-admin-frontend` service)** — removed `LOCALSTACK_ENDPOINT`. The frontend app does not read this var.
- **`compose.yml` (`epr-backend` service)** — removed `LOCALSTACK_ENDPOINT` and `COMMAND_QUEUE_SQS_ENDPOINT`. The backend reads `S3_ENDPOINT` and `SQS_ENDPOINT` for its AWS clients; neither of these names appears in its `src/config.js`.

The vars that actually do the work (`S3_ENDPOINT`, `SQS_ENDPOINT`, `SNS_ENDPOINT`) are untouched.

## Why

Carrying dead config forward misleads anyone reading the compose file into thinking these vars matter. Dropping them makes the intent of the remaining config clearer.

Jira: https://eaflood.atlassian.net/browse/PAE-1360

[PAE-1360]: https://eaflood.atlassian.net/browse/PAE-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ