### PR TITLE
PAE-000: Patch basic-ftp, follow-redirects, protobufjs and inflight

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  'SNYK-JS-INFLIGHT-6095116':
+    - '*':
+        reason: 'Transitively pulled in by @wdio/mocha-framework > mocha > glob. Test-only tooling that runs briefly and exits; memory-leak impact is not exploitable in this context and there is no upstream fix.'
+        expires: '2028-01-01T00:00:00.000Z'

--- a/package-lock.json
+++ b/package-lock.json
@@ -3069,9 +3069,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5717,9 +5717,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -9437,9 +9437,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   },
   "overrides": {
     "eslint": "$eslint",
-    "serialize-javascript": "7.0.5",
-    "lodash": "4.18.1",
-    "basic-ftp": "5.2.2",
-    "axios": "1.15.0"
+    "basic-ftp": "^5.3.0",
+    "follow-redirects": "^1.16.0",
+    "protobufjs": "^7.5.5",
+    "serialize-javascript": "7.0.5"
   },
   "devDependencies": {
     "eslint": "10.1.0",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
Patches three transitive dependency vulnerabilities flagged by `npm audit`, Dependabot and Snyk, and records a scoped ignore for the one remaining issue with no upstream fix.

## basic-ftp ([GHSA-rp42-5vxx-qpwr](https://github.com/advisories/GHSA-rp42-5vxx-qpwr) — high)

Denial of service via unbounded memory consumption in `Client.list()`. Pulled in transitively via `@wdio/cli > @wdio/utils > @puppeteer/browsers > proxy-agent > pac-proxy-agent > get-uri`. An existing `basic-ftp` override was pinned *at* the vulnerable `5.2.2`; this moves it to `^5.3.0`, the first patched release.

## follow-redirects ([GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) — moderate)

Custom authentication headers leak to cross-domain redirect targets. Pulled in via `@wdio/browserstack-service > @browserstack/ai-sdk-node > axios`. Adds an override pinning to `^1.16.0`.

## protobufjs ([GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) — critical)

Arbitrary code execution via prototype pollution in proto parsing. Pulled in via `@wdio/browserstack-service > @browserstack/wdio-browserstack-service > @grpc/grpc-js > @grpc/proto-loader`. Adds an override pinning to `^7.5.5`.

## inflight (SNYK-JS-INFLIGHT-6095116 — medium)

Resource leak with no upstream fix — the package is deprecated and unmaintained. Pulled in via `@wdio/mocha-framework > mocha > glob`. A new `.snyk` policy file scopes an ignore to this advisory with reasoning (test-only tooling, runs briefly and exits) and a 2028 review date. This matches the existing pattern used in `epr-backend-journey-tests`.

## Stale override pruning

Two existing overrides were removed because neither `npm audit` nor Snyk flags any new vulnerability without them, so they were no longer serving a security purpose:

- `axios` (`1.15.0`)
- `lodash` (`4.18.1`)

The `serialize-javascript` and `eslint` overrides were kept — removing `serialize-javascript` resurfaces two Snyk advisories, and the `eslint: $eslint` entry is a compatibility shim for `eslint-plugin-*` peers rather than a security pin.