### PR TITLE
PAE-1385: pin unpinned dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   },
   "overrides": {
     "eslint": "$eslint",
-    "basic-ftp": "^5.3.0",
-    "follow-redirects": "^1.16.0",
-    "protobufjs": "^7.5.5",
+    "basic-ftp": "5.3.0",
+    "follow-redirects": "1.16.0",
+    "protobufjs": "7.5.5",
     "serialize-javascript": "7.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-1385](https://eaflood.atlassian.net/browse/PAE-1385)
pins unpinned caret/tilde dependency ranges in package.json so the new shared CI pin-check (PAE-1385 child 2) stops blocking PRs.

- flattens offending entries to exact versions
- regenerates package-lock.json (no runtime change -- lockfile already resolves to the same versions)

child 1 of PAE-1385; sibling flatten PRs in the other affected repos.

[PAE-1385]: https://eaflood.atlassian.net/browse/PAE-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ