### PR TITLE
PAE-1339: Add advisory type checking to CI

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -40,6 +40,34 @@ jobs:
           npm run format:check
           npm run lint
 
+  type-check:
+    name: Lint Types (advisory)
+    runs-on: ubuntu-latest
+    needs: pr-prep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.12.1
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint types
+        run: |
+          if npm run lint:types; then
+            echo "::notice::Type check passed"
+          else
+            echo "::warning::Type check found errors (advisory — not blocking)"
+          fi
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "page-objects/*": ["./test/page-objects/*"],
+      "components/*": ["./test/components/*"]
+    }
+  },
+  "include": ["test/**/*.js", "wdio.*.conf.js"],
+  "exclude": ["node_modules"]
+}

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -23,6 +23,6 @@
       "components/*": ["./test/components/*"]
     }
   },
-  "include": ["test/**/*.js", "wdio.*.conf.js"],
+  "include": ["test/**/*.js"],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:types": "tsc -p jsconfig.typecheck.json",
     "postinstall": "npm run setup:husky",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
     "report": "allure generate allure-results --single-file --clean",


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)

## Summary

Introduces type checking as an advisory CI step for this repo, mirroring PAE-1339's rollout in [epr-backend-journey-tests #441](https://github.com/DEFRA/epr-backend-journey-tests/pull/441) and [epr-frontend-journey-tests #310](https://github.com/DEFRA/epr-frontend-journey-tests/pull/310).

- `jsconfig.typecheck.json` at repo root covers `test/**/*.js` with `allowJs` / `checkJs` / `strictNullChecks` on, `noImplicitAny` off — matches the broader rollout's starting posture. Path aliases (`~`, `page-objects`, `components`) are mirrored from `jsconfig.json` so the type checker can resolve the codebase's own imports. `moduleResolution` is set to `Bundler` because the codebase uses extension-less `esm-module-alias` imports that NodeNext resolution rejects.
- `wdio.*.conf.js` configs are deliberately out of scope — they are scaffolded boilerplate from the WDIO CLI, not test code we maintain, and most of their type errors are JSDoc / WDIO-globals artefacts.
- `lint:types` script added to `package.json`. `typescript` resolves transitively via `@wdio` packages (matches epr-backend-journey-tests).
- A new `Lint Types (advisory)` job in the PR workflow runs the script; it raises a GitHub `::warning::` annotation when type errors are present without failing the build.

Baseline on `main` at introduction: **40** type errors, dominated by `TS18046` (17, mostly `unknown` from `response.body.json()` in `apicalls.js`) and `TS2339` (14). Fixing them is tracked separately; this PR only wires up the advisory step so the error count is visible on every PR. A follow-up will flip it to blocking once the count is at zero.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ