### PR TITLE
PAE-1421: add report submissions CSV e2e test with submitted tonnage …

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -145,6 +145,23 @@ services:
       start_period: 2s
       retries: 3
 
+  defra-id-stub:
+    image: defradigital/cdp-defra-id-stub:latest
+    ports:
+      - '3200:3200'
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      APP_BASE_URL: http://defra-id-stub:3200
+      NODE_ENV: development
+      OIDC_BASE_PATH: /cdp-defra-id-stub
+      OIDC_CLIENT_ID: 63983fc2-cfff-45bb-8ec2-959e21062b9a
+      OIDC_CLIENT_SECRET: test_value
+      PORT: 3200
+      REDIS_HOST: redis
+      USE_SINGLE_INSTANCE_CACHE: true
+
   mongodb:
     image: mongo:8.2.7
     restart: always
@@ -180,6 +197,8 @@ services:
       FEATURE_FLAG_REPORTS: true
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://epr-re-ex-entra-stub:3010/.well-known/openid-configuration
       ADMIN_UI_ENTRA_CLIENT_ID: clientId
+      DEFRA_ID_CLIENT_ID: 63983fc2-cfff-45bb-8ec2-959e21062b9a
+      DEFRA_ID_OIDC_WELL_KNOWN_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       SERVICE_MAINTAINER_EMAILS: '["ea@test.gov.uk"]'
       CDP_UPLOADER_URL: http://cdp-uploader:7337
       SQS_ENDPOINT: http://floci:4566

--- a/test/page-objects/report.submissions.page.js
+++ b/test/page-objects/report.submissions.page.js
@@ -1,0 +1,38 @@
+import { Page } from 'page-objects/page'
+import { browser } from '@wdio/globals'
+
+class ReportSubmissionsPage extends Page {
+  open() {
+    return super.open('/report-submissions')
+  }
+
+  async fetchCsv() {
+    return browser.execute(async () => {
+      const form = document.querySelector('#main-content form')
+      if (!form) throw new Error('Report submissions form not found')
+
+      const formData = new URLSearchParams()
+      for (const input of form.querySelectorAll('input[name]')) {
+        formData.set(input.name, input.value)
+      }
+
+      const response = await fetch('/report-submissions', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded;charset=UTF-8'
+        },
+        body: formData.toString()
+      })
+
+      return {
+        status: response.status,
+        contentDisposition: response.headers.get('content-disposition'),
+        contentType: response.headers.get('content-type'),
+        body: await response.text()
+      }
+    })
+  }
+}
+
+export default new ReportSubmissionsPage()

--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -61,4 +61,60 @@ describe('Report Submissions page', () => {
     await expect(cols[12]).toBeTruthy()
     await expect(cols[14]).toBeTruthy()
   })
+
+  it('should include all expected column headers in the CSV download @reportsubmissions', async () => {
+    await LoginPage.open()
+    await LoginPage.enterCredentials('ea@test.gov.uk', 'pass')
+    await LoginPage.submitCredentials()
+
+    await Navigation.clickOnLink('Report submissions')
+
+    const csv = await ReportSubmissionsPage.fetchCsv()
+    await expect(csv.status).toEqual(200)
+
+    const rows = csv.body
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+    const headerIndex = rows.findIndex((row) =>
+      row.startsWith('"Organisation name"')
+    )
+    await expect(headerIndex).toBeGreaterThanOrEqual(0)
+
+    const headerRow = rows[headerIndex]
+    const expectedHeaders = [
+      'Organisation name',
+      'Organisation registered approver contact number',
+      'Organisation registered approver person email address',
+      'Organisation registered submitter contact number',
+      'Organisation registered submitter email address',
+      'Material',
+      'Accreditation No',
+      'Registered No',
+      'Report Type',
+      'Report Period',
+      'Due Date',
+      'Submitted Date',
+      'Submitted By',
+      'Tonnage received for recycling',
+      'Tonnage recycled',
+      'Tonnage exported for recycling',
+      'Tonnage sent on, total',
+      'Tonnage sent on to a reprocessor',
+      'Tonnage sent on to an exporter',
+      'Tonnage sent on to other facilities',
+      'Tonnage of PRNs/PERNs issued',
+      'Total revenue from PRNs/PERNs',
+      'Average PRN/PERN price per tonne',
+      'Tonnage received but not recycled',
+      'Tonnage received but not exported',
+      'Tonnage exported that was stopped',
+      'Tonnage exported that was refused',
+      'Tonnage repatriated',
+      'Note to regulator'
+    ]
+
+    for (const header of expectedHeaders) {
+      await expect(headerRow).toContain(header)
+    }
+  })
 })

--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -48,25 +48,19 @@ describe('Report Submissions page', () => {
     const rows = csv.body
       .split(/\r?\n/)
       .filter((line) => line.trim().length > 0)
-    const headerIndex = rows.findIndex((row) =>
-      row.startsWith('"Organisation name"')
-    )
+    const headerIndex = rows.findIndex((row) => row.startsWith('"Regulator"'))
     await expect(headerIndex).toBeGreaterThanOrEqual(0)
     const dataRows = rows.slice(headerIndex + 1)
 
     const orgRow = dataRows.find((row) => row.includes(orgName))
     await expect(orgRow).toBeDefined()
     const cols = orgRow.split('","')
-    await expect(cols[11]).toBeTruthy()
     await expect(cols[12]).toBeTruthy()
-    await expect(cols[14]).toBeTruthy()
+    await expect(cols[13]).toBeTruthy()
+    await expect(cols[15]).toBeTruthy()
   })
 
   it('should include all expected column headers in the CSV download @reportsubmissions', async () => {
-    await LoginPage.open()
-    await LoginPage.enterCredentials('ea@test.gov.uk', 'pass')
-    await LoginPage.submitCredentials()
-
     await Navigation.clickOnLink('Report submissions')
 
     const csv = await ReportSubmissionsPage.fetchCsv()
@@ -75,13 +69,12 @@ describe('Report Submissions page', () => {
     const rows = csv.body
       .split(/\r?\n/)
       .filter((line) => line.trim().length > 0)
-    const headerIndex = rows.findIndex((row) =>
-      row.startsWith('"Organisation name"')
-    )
+    const headerIndex = rows.findIndex((row) => row.startsWith('"Regulator"'))
     await expect(headerIndex).toBeGreaterThanOrEqual(0)
 
     const headerRow = rows[headerIndex]
     const expectedHeaders = [
+      'Regulator',
       'Organisation name',
       'Organisation registered approver contact number',
       'Organisation registered approver person email address',

--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -1,0 +1,64 @@
+import { browser, expect } from '@wdio/globals'
+
+import {
+  createLinkedOrganisation,
+  updateMigratedOrganisation,
+  createSubmittedReport
+} from '../support/apicalls.js'
+import LoginPage from 'page-objects/login.js'
+import Navigation from 'page-objects/navigation.js'
+import ReportSubmissionsPage from 'page-objects/report.submissions.page'
+
+describe('Report Submissions page', () => {
+  let orgName
+
+  before(async () => {
+    const { refNo, organisation } = await createLinkedOrganisation([
+      { material: 'Paper or board (R3)', wasteProcessingType: 'Reprocessor' }
+    ])
+    orgName = organisation.companyName
+
+    await updateMigratedOrganisation(refNo, [
+      {
+        regNumber: 'REPROCESS-001',
+        status: 'approved',
+        reprocessingType: 'input'
+      }
+    ])
+
+    await createSubmittedReport(refNo)
+  })
+
+  it('Should be able to download Report Submissions if logged in @reportsubmissions', async () => {
+    await LoginPage.open()
+    await expect(browser).toHaveTitle(expect.stringContaining('Login'))
+    await LoginPage.enterCredentials('ea@test.gov.uk', 'pass')
+    await LoginPage.submitCredentials()
+
+    await Navigation.clickOnLink('Report submissions')
+
+    const csv = await ReportSubmissionsPage.fetchCsv()
+    await expect(csv.status).toEqual(200)
+    await expect(csv.contentType).toContain('text/csv')
+    await expect(csv.contentDisposition).toContain('attachment')
+    await expect(csv.body).toContain('Organisation name')
+    await expect(csv.body).toContain('Tonnage received for recycling')
+    await expect(csv.body).toContain(orgName)
+
+    const rows = csv.body
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+    const headerIndex = rows.findIndex((row) =>
+      row.startsWith('"Organisation name"')
+    )
+    await expect(headerIndex).toBeGreaterThanOrEqual(0)
+    const dataRows = rows.slice(headerIndex + 1)
+
+    const orgRow = dataRows.find((row) => row.includes(orgName))
+    await expect(orgRow).toBeDefined()
+    const cols = orgRow.split('","')
+    await expect(cols[11]).toBeTruthy()
+    await expect(cols[12]).toBeTruthy()
+    await expect(cols[14]).toBeTruthy()
+  })
+})

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -8,6 +8,7 @@ import { BaseAPI } from '../apis/base-api.js'
 import { trackCreatedOrgId } from './cleanup-tracker.js'
 import { expect } from '@wdio/globals'
 import { request } from 'undici'
+import { randomUUID } from 'crypto'
 
 async function getEntraToken() {
   const entraUrl = 'http://localhost:3010/sign'
@@ -21,6 +22,225 @@ async function getEntraToken() {
   })
   const data = await response.body.json()
   return data.access_token
+}
+
+// Registers a throwaway user with the Defra ID stub and returns a Bearer token
+// with standardUser scope for the given defraOrgId.
+// The Host header is spoofed on every request so the stub embeds
+// http://defra-id-stub:3200/cdp-defra-id-stub as the JWT issuer — which is
+// what the backend is configured to trust.
+async function getDefraUserToken(defraOrgId) {
+  const stubUrl = 'http://localhost:3200'
+  const stubHost = 'defra-id-stub:3200'
+  const userId = randomUUID()
+  const email = `test-${userId}@example.com`
+  const clientId = '63983fc2-cfff-45bb-8ec2-959e21062b9a'
+
+  await request(`${stubUrl}/cdp-defra-id-stub/API/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: stubHost },
+    body: JSON.stringify({
+      userId,
+      email,
+      firstName: 'Test',
+      lastName: 'User',
+      loa: '1',
+      aal: '1',
+      enrolmentCount: 1,
+      enrolmentRequestCount: 1
+    })
+  })
+
+  const relParams = new URLSearchParams({
+    csrfToken: randomUUID(),
+    userId,
+    relationshipId: 'relId1',
+    organisationId: defraOrgId,
+    organisationName: 'Test Organisation',
+    relationshipRole: 'role',
+    roleName: 'User',
+    roleStatus: 'Status',
+    // eslint-disable-next-line camelcase
+    redirect_uri: 'http://localhost:3000/'
+  })
+  await request(
+    `${stubUrl}/cdp-defra-id-stub/register/${userId}/relationship`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        host: stubHost
+      },
+      body: relParams.toString()
+    }
+  )
+
+  const authParams = new URLSearchParams({
+    user: email,
+    // eslint-disable-next-line camelcase
+    client_id: clientId,
+    // eslint-disable-next-line camelcase
+    response_type: 'code',
+    // eslint-disable-next-line camelcase
+    redirect_uri: 'http://0.0.0.0:3001/health',
+    state: 'state',
+    scope: 'email'
+  })
+  const authResponse = await request(
+    `${stubUrl}/cdp-defra-id-stub/authorize?${authParams.toString()}`,
+    { method: 'GET', headers: { host: stubHost } }
+  )
+  if (authResponse.statusCode !== 302) {
+    const body = await authResponse.body.text()
+    throw new Error(
+      `Defra ID authorize returned ${authResponse.statusCode}: ${body}`
+    )
+  }
+  const sessionId = authResponse.headers.location.split('sessionId=')[1]
+
+  const tokenResponse = await request(`${stubUrl}/cdp-defra-id-stub/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: stubHost },
+    body: JSON.stringify({
+      // eslint-disable-next-line camelcase
+      client_id: clientId,
+      // eslint-disable-next-line camelcase
+      client_secret: 'test_value',
+      // eslint-disable-next-line camelcase
+      grant_type: 'authorization_code',
+      code: sessionId
+    })
+  })
+  const tokenData = await tokenResponse.body.json()
+  return tokenData.access_token
+}
+
+// Returns the most recently completed reporting period for the given cadence.
+// Quarterly: periods 1–4 map to Q1–Q4. Monthly: periods 1–12 map to Jan–Dec.
+function lastCompletedPeriod(cadence) {
+  const now = new Date()
+  const month = now.getUTCMonth() + 1
+  const year = now.getUTCFullYear()
+
+  if (cadence === 'monthly') {
+    return month === 1
+      ? { year: year - 1, period: 12 }
+      : { year, period: month - 1 }
+  }
+
+  const currentQuarter = Math.ceil(month / 3)
+  return currentQuarter === 1
+    ? { year: year - 1, period: 4 }
+    : { year, period: currentQuarter - 1 }
+}
+
+// Creates and submits a report for a registration, transitioning it through
+// in_progress → ready_to_submit → submitted.
+// Cadence is determined by matching the CSV generator's logic: monthly only
+// when the linked accreditation is approved/suspended with an accreditationNumber.
+// validFrom is set to the period start so the CSV generates exactly one row for
+// this registration regardless of when the test runs.
+export async function createSubmittedReport(refNo, registrationIndex = 0) {
+  const baseAPI = new BaseAPI()
+  const entraToken = await getEntraToken()
+  const entraAuthHeader = { Authorization: `Bearer ${entraToken}` }
+
+  const orgResponse = await baseAPI.get(
+    `/v1/organisations/${refNo}`,
+    entraAuthHeader
+  )
+  expect(orgResponse.statusCode).toBe(200)
+  const orgData = await orgResponse.body.json()
+
+  const registration = orgData.registrations[registrationIndex]
+  const registrationId = registration.id
+
+  const linkedAccreditation = registration.accreditationId
+    ? orgData.accreditations.find(
+        (a) =>
+          a.id === registration.accreditationId &&
+          (a.status === 'approved' || a.status === 'suspended') &&
+          a.accreditationNumber
+      )
+    : null
+  const cadence = linkedAccreditation ? 'monthly' : 'quarterly'
+  const { year, period } = lastCompletedPeriod(cadence)
+
+  const periodStartMonth = cadence === 'monthly' ? period : (period - 1) * 3 + 1
+  orgData.registrations[registrationIndex].validFrom =
+    `${year}-${String(periodStartMonth).padStart(2, '0')}-01`
+
+  // When the accreditation isn't approved the CSV generator treats this as quarterly,
+  // but the backend uses accreditationId presence to enforce monthly cadence.
+  // Delete the key (not null) so JSON omits it — schema only allows absent, not explicit null.
+  if (!linkedAccreditation) {
+    delete orgData.registrations[registrationIndex].accreditationId
+  }
+
+  const defraOrgId = randomUUID()
+  orgData.status = 'active'
+  orgData.statusHistory = [
+    ...(orgData.statusHistory || []),
+    { status: 'active', updatedAt: new Date().toISOString() }
+  ]
+  orgData.linkedDefraOrganisation = {
+    orgId: defraOrgId,
+    orgName: 'Test Organisation',
+    linkedAt: new Date().toISOString(),
+    linkedBy: { email: 'test@example.com', id: randomUUID() }
+  }
+
+  const activateResponse = await baseAPI.put(
+    `/v1/dev/organisations/${refNo}`,
+    JSON.stringify({ organisation: orgData }),
+    entraAuthHeader
+  )
+  if (activateResponse.statusCode !== 200) {
+    const body = await activateResponse.body.text()
+    throw new Error(
+      `activate PUT returned ${activateResponse.statusCode}: ${body}`
+    )
+  }
+
+  const defraToken = await getDefraUserToken(defraOrgId)
+  const defraAuthHeader = { Authorization: `Bearer ${defraToken}` }
+  const jsonHeaders = { ...defraAuthHeader, 'content-type': 'application/json' }
+
+  const basePath = `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+
+  const createResponse = await baseAPI.post(basePath, '', defraAuthHeader)
+  if (createResponse.statusCode !== 201) {
+    const body = await createResponse.body.text()
+    throw new Error(
+      `POST ${basePath} returned ${createResponse.statusCode}: ${body}`
+    )
+  }
+  let version = (await createResponse.body.json()).version
+
+  const patchResponse = await baseAPI.patch(
+    basePath,
+    JSON.stringify({ tonnageRecycled: 10, tonnageNotRecycled: 0 }),
+    jsonHeaders
+  )
+  expect(patchResponse.statusCode).toBe(200)
+  version = (await patchResponse.body.json()).version
+
+  const readyResponse = await baseAPI.post(
+    `${basePath}/status`,
+    JSON.stringify({ status: 'ready_to_submit', version }),
+    jsonHeaders
+  )
+  expect(readyResponse.statusCode).toBe(200)
+  version += 1
+
+  const submitResponse = await baseAPI.post(
+    `${basePath}/status`,
+    JSON.stringify({ status: 'submitted', version }),
+    jsonHeaders
+  )
+  expect(submitResponse.statusCode).toBe(200)
+
+  return { organisationId: refNo, registrationId, year, cadence, period }
 }
 
 export async function updateMigratedOrganisation(refNo, updateDataRows) {


### PR DESCRIPTION
Ticket: [PAE-1421](https://eaflood.atlassian.net/browse/PAE-1421)
- Adds an e2e test for the Report Submissions CSV download
- Adds a ReportSubmissionsPage page object that fetches the CSV via an in-browser fetch POST
- Extends apicalls.js with createSubmittedReport, which builds a complete data chain — org creation, registration approval, org activation, and report submission — so the CSV always contains a deterministic row with tonnage and submission data

[PAE-1421]: https://eaflood.atlassian.net/browse/PAE-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ