### PR TITLE
PAE-250: Prune stale axios override

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "axios": "1.15.2",
     "eslint": "$eslint",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Removes the `axios` entry from `package.json` `overrides` because it is no longer changing anything — `@wdio/browserstack-service@9.26.1 > @browserstack/ai-sdk-node@1.5.17` already pulls in `axios@1.15.2`, the same version the override was pinning.

The override was tested in isolation by removing it from `package.json`, regenerating the lockfile, and running both `npm audit` and `snyk test`. Both reported zero issues with the override gone.

The remaining overrides (`serialize-javascript`, `uuid`, plus the `eslint: "$eslint"` self-reference shim) were verified as still required: removing `serialize-javascript` brings back 3 high-severity vulnerabilities (mocha → old `serialize-javascript`); removing `uuid` brings back 4 moderate-severity vulnerabilities (`uuid` <14.0.0 buffer bounds check). The `eslint: "$eslint"` self-reference is a compatibility shim, not a vulnerability mitigation, so it was left out of this sweep.

## Why prune it

The shared CI `Preparation` step rejects unpinned ranges in `overrides`, which means each entry is a permanent forced version that won't update with the rest of the tree until someone removes it. Stale overrides that no longer affect resolution add maintenance noise — they're easily mistaken for active mitigations during future audits and force the reviewer to verify why each one is still there. Pruning them keeps the override list a meaningful list of active mitigations.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ