### PR TITLE
PAE-1436 align test with updated error message

### DIFF
--- a/test/specs/systemlogs.e2e.js
+++ b/test/specs/systemlogs.e2e.js
@@ -103,7 +103,7 @@ describe('System logs search @searchsystemlogs', () => {
 
     await expect($('.govuk-error-summary')).toHaveText(
       expect.stringContaining(
-        'Enter an organisation reference number or email address'
+        'Enter an organisation reference number, email address or event type'
       )
     )
   })


### PR DESCRIPTION
Ticket: [PAE-1436](https://eaflood.atlassian.net/browse/PAE-1436)
## Description

Updates expected error message in test to align with what service produces

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1436]: https://eaflood.atlassian.net/browse/PAE-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ