### PR TITLE
PAE-250: Fix basic-ftp DoS and prune stale ip-address override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3068,9 +3068,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "overrides": {
     "eslint": "$eslint",
-    "ip-address": "10.2.0",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Bumps `basic-ftp` past the patched range and removes a transitive override that is no longer earning its keep.

### `basic-ftp` upgrade

[GHSA-rpmf-866q-6p89](https://github.com/advisories/GHSA-rpmf-866q-6p89): a malicious FTP server can cause client-side denial of service through unbounded multiline control-response buffering. WebdriverIO's session-management chain pulls `basic-ftp` in transitively. `npm audit fix` lifts it from `<=5.3.0` to `5.3.1`, which contains the patch — no semver-incompatible bumps anywhere else.

### `ip-address` override removed

The pin to `ip-address@10.2.0` was added previously to dodge a vulnerable transitive copy. Both `npm audit` and `snyk test` now report clean without the override, so the upstream chain has caught up — the pin is just deadweight that masks future drift if the dep ever breaks compatibility.

The `serialize-javascript`, `uuid`, and `eslint` overrides remain — `serialize-javascript` and `uuid` still cover live transitive vulnerabilities (mocha pulls in old `serialize-javascript`; `@wdio/browserstack-service` pulls in old `uuid`), and `eslint` is a compatibility shim, not a security pin.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ