### PR TITLE
PAE-1408: append random suffix to company names to ensure uniqueness

### DIFF
--- a/test/support/generator.js
+++ b/test/support/generator.js
@@ -175,7 +175,7 @@ export class Organisation {
       ',' +
       this.postcode
 
-    this.companyName = fakerEN_GB.company.name() + ' Limited'
+    this.companyName = `${fakerEN_GB.company.name()} Limited ${fakerEN_GB.string.alphanumeric(8)}`
 
     this.numberOfNations = Math.floor(Math.random() * nations.length) + 1
   }
@@ -277,7 +277,7 @@ export class Registration {
       ? `${orgId}`
       : `${fakerEN_GB.number.int({ min: 500000, max: 999999 })}`
     this.jobTitle = fakerEN_GB.person.jobTitle()
-    this.companyName = fakerEN_GB.company.name() + ' Limited'
+    this.companyName = `${fakerEN_GB.company.name()} Limited ${fakerEN_GB.string.alphanumeric(8)}`
 
     this.fileId1 = fakerEN_GB.string.uuid()
     this.fileId2 = fakerEN_GB.string.uuid()


### PR DESCRIPTION
Ticket: [PAE-1408](https://eaflood.atlassian.net/browse/PAE-1408)
## Description

Appends an 8-character alphanumeric suffix to generated company names in
Organisation and Registration to prevent duplicate name errors across test runs

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1408]: https://eaflood.atlassian.net/browse/PAE-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ