### PR TITLE
PAE-1443/1444: E2E smoke for waste records export tab

### DIFF
--- a/test/page-objects/waste.records.export.page.js
+++ b/test/page-objects/waste.records.export.page.js
@@ -1,0 +1,38 @@
+import { Page } from 'page-objects/page'
+import { browser } from '@wdio/globals'
+
+class WasteRecordsExportPage extends Page {
+  open() {
+    return super.open('/waste-records-export')
+  }
+
+  async fetchCsv() {
+    return browser.execute(async () => {
+      const form = document.querySelector('#main-content form')
+      if (!form) throw new Error('Waste records export form not found')
+
+      const formData = new URLSearchParams()
+      for (const input of form.querySelectorAll('input[name]')) {
+        formData.set(input.name, input.value)
+      }
+
+      const response = await fetch('/waste-records-export', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded;charset=UTF-8'
+        },
+        body: formData.toString()
+      })
+
+      return {
+        status: response.status,
+        contentDisposition: response.headers.get('content-disposition'),
+        contentType: response.headers.get('content-type'),
+        body: await response.text()
+      }
+    })
+  }
+}
+
+export default new WasteRecordsExportPage()

--- a/test/specs/wasterecordsexport.e2e.js
+++ b/test/specs/wasterecordsexport.e2e.js
@@ -1,0 +1,44 @@
+import { browser, expect } from '@wdio/globals'
+
+import LoginPage from 'page-objects/login.js'
+import Navigation from 'page-objects/navigation.js'
+import WasteRecordsExportPage from 'page-objects/waste.records.export.page'
+
+describe('Waste records export page', () => {
+  it('Should download a CSV with the expected metadata header columns @wasterecordsexport', async () => {
+    await LoginPage.open()
+    await expect(browser).toHaveTitle(expect.stringContaining('Login'))
+    await LoginPage.enterCredentials('ea@test.gov.uk', 'pass')
+    await LoginPage.submitCredentials()
+
+    await Navigation.clickOnLink('Waste records export')
+
+    const csv = await WasteRecordsExportPage.fetchCsv()
+    await expect(csv.status).toEqual(200)
+    await expect(csv.contentType).toContain('text/csv')
+    await expect(csv.contentDisposition).toContain('attachment')
+    await expect(csv.contentDisposition).toContain('waste-records-')
+
+    const rows = csv.body
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+    await expect(rows.length).toBeGreaterThanOrEqual(1)
+
+    const headerRow = rows[0]
+    const expectedMetadataHeaders = [
+      'Regulator',
+      'Organisation Name',
+      'Material',
+      'Operator Processing Type',
+      'Accredited',
+      'Waste Record Type',
+      'Submitted At',
+      'Included in Waste Balance',
+      'Row ID'
+    ]
+
+    for (const header of expectedMetadataHeaders) {
+      await expect(headerRow).toContain(header)
+    }
+  })
+})


### PR DESCRIPTION
Ticket: [PAE-1443](https://eaflood.atlassian.net/browse/PAE-1443)
## Summary

Adds an E2E smoke test for the new "Waste records export" admin tab. Patterned on `reportsubmissions.e2e.js`.

- New page object `test/page-objects/waste.records.export.page.js` (mirrors `report.submissions.page.js`).
- New spec `test/specs/wasterecordsexport.e2e.js` — signs in as a service maintainer, navigates to the new tab, downloads the CSV, asserts status 200, `Content-Type: text/csv`, `Content-Disposition` contains `attachment` and `waste-records-`, and that the header row contains all 9 metadata columns.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-08-waste-records-export-design.md` (in claude-reex meta-repo)
- Plan: `docs/superpowers/plans/2026-05-08-waste-records-export.md`

## Depends on

- Backend PR: https://github.com/DEFRA/epr-backend/pull/1163
- Admin frontend PR: https://github.com/DEFRA/epr-re-ex-admin-frontend/pull/382

Both must be deployed for this test to pass.


[PAE-1443]: https://eaflood.atlassian.net/browse/PAE-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ