### PR TITLE
PAE-250: Fix fast-xml-builder XML injection and XXE vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5541,9 +5541,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -5556,9 +5556,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -5568,7 +5568,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "overrides": {
     "eslint": "$eslint",
+    "fast-xml-parser": "5.7.3",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Pins `fast-xml-parser` to `5.7.3` via npm `overrides` to remove two high-severity advisories against `fast-xml-builder`:

- [GHSA-5wm8-gmm8-39j9](https://github.com/advisories/GHSA-5wm8-gmm8-39j9) — attribute values with unwanted quotes can bypass the sanitisation, allowing malicious or unwanted attributes through.
- [GHSA-45c6-75p6-83cc](https://github.com/advisories/GHSA-45c6-75p6-83cc) — the comment-value regex can be bypassed, opening an XML injection path.

Snyk flags the same paths as [SNYK-JS-FASTXMLBUILDER-16540557](https://security.snyk.io/vuln/SNYK-JS-FASTXMLBUILDER-16540557) and [SNYK-JS-FASTXMLBUILDER-16540558](https://security.snyk.io/vuln/SNYK-JS-FASTXMLBUILDER-16540558).

## Why an override

`fast-xml-parser` is pulled in transitively through `@wdio/cli > @wdio/utils > edgedriver`. The `edgedriver` range (`^5.3.3`) was resolving to `5.7.1`, which still depends on the vulnerable `fast-xml-builder ^1.1.5`. Pinning to `5.7.3` pulls patched `fast-xml-builder ^1.1.7` (resolves to `1.1.9`).

## Verification

- `npm audit` reports 0 vulnerabilities on the new lockfile.
- `npm ls fast-xml-builder` confirms `fast-xml-parser@5.7.3 (overridden) → fast-xml-builder@1.1.9`.
- The other simple overrides (`serialize-javascript: 7.0.5`, `uuid: 14.0.0`) were tested for staleness — both still suppress active findings, so they stay.
- The existing `.snyk` ignore for `SNYK-JS-INFLIGHT-6095116` was tested too; Snyk still flags inflight via `@wdio/mocha-framework > mocha > glob`, so the ignore stays.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ