### PR TITLE
PAE-250: Remove stale fast-xml-parser override

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "overrides": {
     "eslint": "$eslint",
-    "fast-xml-parser": "5.7.3",
     "serialize-javascript": "7.0.5",
     "uuid": "14.0.0"
   },


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The override was originally pinning `fast-xml-parser` to `5.7.3` to silence a transitive vulnerability. The parent packages have since updated their dependency ranges, so the override no longer changes the resolved tree.

Verified by removing it, re-resolving the lockfile, and confirming both `npm audit` and `snyk test` report no new findings. The remaining `serialize-javascript` and `uuid` overrides plus the `SNYK-JS-INFLIGHT-6095116` policy ignore were tested the same way and are all still required, so they stay.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ