### PR TITLE
PAE-1490: Add self-issued (free) tonnage to expected CSV headers

### DIFF
--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -1,5 +1,7 @@
 import { browser, expect } from '@wdio/globals'
 
+/** @typedef {{ status: number, contentType: string | null, contentDisposition: string | null, body: string }} CsvResponse */
+
 import {
   createLinkedOrganisation,
   updateMigratedOrganisation,
@@ -37,7 +39,9 @@ describe('Report Submissions page', () => {
 
     await Navigation.clickOnLink('Report submissions')
 
-    const csv = await ReportSubmissionsPage.fetchCsv()
+    const csv = /** @type {CsvResponse} */ (
+      /** @type {unknown} */ (await ReportSubmissionsPage.fetchCsv())
+    )
     await expect(csv.status).toEqual(200)
     await expect(csv.contentType).toContain('text/csv')
     await expect(csv.contentDisposition).toContain('attachment')
@@ -63,7 +67,9 @@ describe('Report Submissions page', () => {
   it('should include all expected column headers in the CSV download @reportsubmissions', async () => {
     await Navigation.clickOnLink('Report submissions')
 
-    const csv = await ReportSubmissionsPage.fetchCsv()
+    const csv = /** @type {CsvResponse} */ (
+      /** @type {unknown} */ (await ReportSubmissionsPage.fetchCsv())
+    )
     await expect(csv.status).toEqual(200)
 
     const rows = csv.body

--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -54,7 +54,7 @@ describe('Report Submissions page', () => {
 
     const orgRow = dataRows.find((row) => row.includes(orgName))
     await expect(orgRow).toBeDefined()
-    const cols = orgRow.split('","')
+    const cols = /** @type {string} */ (orgRow).split('","')
     await expect(cols[12]).toBeTruthy()
     await expect(cols[13]).toBeTruthy()
     await expect(cols[15]).toBeTruthy()
@@ -96,6 +96,7 @@ describe('Report Submissions page', () => {
       'Tonnage sent on to an exporter',
       'Tonnage sent on to other facilities',
       'Tonnage of PRNs/PERNs issued',
+      'Self-issued (free) tonnage',
       'Total revenue from PRNs/PERNs',
       'Average PRN/PERN price per tonne',
       'Tonnage received but not recycled',


### PR DESCRIPTION
Ticket: [PAE-1490](https://eaflood.atlassian.net/browse/PAE-1490)
## Changes

- Add `'Self-issued (free) tonnage'` to the `expectedHeaders` array in the report submissions E2E test

[PAE-1490]: https://eaflood.atlassian.net/browse/PAE-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ