### PR TITLE
PAE-250: Override axios to 1.16.1 to fix SSRF and prototype pollution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3037,13 +3037,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   },
   "overrides": {
     "eslint": "$eslint",
+    "axios": "1.16.1",
     "serialize-javascript": "7.0.5",
-    "tmp": "0.2.6",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What

`axios` 1.15.2 reached the dependency tree via `@wdio/browserstack-service > @browserstack/ai-sdk-node`, carrying high-severity SSRF and prototype-pollution issues (GHSA-pjwm-pj3p-43mv, GHSA-898c-q2cr-xwhg, GHSA-654m-c8p4-x5fp, GHSA-35jp-ww65-95wh; SNYK-JS-AXIOS-17111062/079/081/086). All are fixed in `axios` 1.16.0.

The BrowserStack service hasn't shipped a release pulling the patched line, so this pins `axios` to **1.16.1** (latest) via `overrides`. `npm audit` and `snyk test` are both clean afterwards.

## Also in this change

The `tmp` override was tested for staleness by removing it and re-resolving — the tree now resolves `tmp` to a safe version without it, so it's been dropped. The `serialize-javascript` and `uuid` overrides remain load-bearing (removing them reintroduces high/medium vulnerabilities via `mocha` and `exceljs`) and are retained. The existing `inflight` Snyk ignore was also re-tested and is still required, so it stays.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ