### PR TITLE
PAE-1558: Assert FOI columns in waste-records export journey test

### DIFF
--- a/test/specs/wasterecordsexport.e2e.js
+++ b/test/specs/wasterecordsexport.e2e.js
@@ -28,9 +28,11 @@ describe('Waste records export page', () => {
     const expectedMetadataHeaders = [
       'Regulator',
       'Organisation Name',
+      'Registration Number',
       'Material',
       'Operator Processing Type',
       'Accredited',
+      'Accreditation Number',
       'Waste Record Type',
       'Submitted At',
       'Included in Waste Balance',


### PR DESCRIPTION
Ticket: [PAE-1558](https://eaflood.atlassian.net/browse/PAE-1558)

## What

Adds `Registration Number` and `Accreditation Number` to the `expectedMetadataHeaders` list the waste-records export journey test asserts, placed to match the export's column order (Registration Number after Organisation Name, Accreditation Number after Accredited).

## Why

The backend waste-records CSV export gained these two columns for FOI/EIR data requests ([epr-backend #1301](https://github.com/DEFRA/epr-backend/pull/1301)). The journey test asserts each header with `toContain`, so it stayed green without them — but that left the new regulator-facing columns unguarded end-to-end. This closes the coverage gap.


[PAE-1558]: https://eaflood.atlassian.net/browse/PAE-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ