### PR TITLE
PAE-1554: add submissionNumber to report API path in createSubmittedReport

### DIFF
--- a/test/page-objects/unsubmit.confirmation.page.js
+++ b/test/page-objects/unsubmit.confirmation.page.js
@@ -3,7 +3,7 @@ import { $ } from '@wdio/globals'
 
 class UnsubmitConfirmationPage extends Page {
   async getWarningText() {
-    return await $('#main-content > div > div > div > strong').getText()
+    return await $('.govuk-warning-text__text').getText()
   }
 
   async confirmUnsubmit() {

--- a/test/page-objects/unsubmit.confirmation.page.js
+++ b/test/page-objects/unsubmit.confirmation.page.js
@@ -3,7 +3,7 @@ import { $ } from '@wdio/globals'
 
 class UnsubmitConfirmationPage extends Page {
   async getWarningText() {
-    return await $('.govuk-warning-text__text').getText()
+    return await $('#main-content > div > div > div > strong').getText()
   }
 
   async confirmUnsubmit() {

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -234,7 +234,7 @@ export async function createSubmittedReport(refNo, registrationIndex = 0) {
   const defraAuthHeader = { Authorization: `Bearer ${defraToken}` }
   const jsonHeaders = { ...defraAuthHeader, 'content-type': 'application/json' }
 
-  const basePath = `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/1`
+  const basePath = `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/1`
 
   const createResponse = await baseAPI.post(basePath, '', defraAuthHeader)
   if (createResponse.statusCode !== 201) {

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -234,7 +234,7 @@ export async function createSubmittedReport(refNo, registrationIndex = 0) {
   const defraAuthHeader = { Authorization: `Bearer ${defraToken}` }
   const jsonHeaders = { ...defraAuthHeader, 'content-type': 'application/json' }
 
-  const basePath = `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}`
+  const basePath = `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/1`
 
   const createResponse = await baseAPI.post(basePath, '', defraAuthHeader)
   if (createResponse.statusCode !== 201) {


### PR DESCRIPTION
Ticket: [PAE-1554](https://eaflood.atlassian.net/browse/PAE-1554)
Add submissionNumber segment to the report basePath used in createSubmittedReport, matching the updated backend route that now requires submissionNumber in all report paths.

[PAE-1554]: https://eaflood.atlassian.net/browse/PAE-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ