### PR TITLE
PAE-250: Fix form-data CRLF injection vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5883,16 +5883,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6413,9 +6413,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   },
   "overrides": {
     "eslint": "$eslint",
+    "form-data": "4.0.6",
     "@grpc/grpc-js": "1.13.5",
     "serialize-javascript": "7.0.5",
-    "tmp": "0.2.7",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Addresses a form-data vulnerability surfaced by Snyk in this admin-frontend functional test suite, and prunes a stale override.

- **form-data** (moderate) — carriage-return/line-feed characters in multipart field names and filenames were not escaped, allowing header injection (SNYK-JS-FORMDATA-17337015). The vulnerable copy is pulled in transitively through `@wdio/browserstack-service > @browserstack/ai-sdk-node > axios`. An `overrides` entry pins form-data to 4.0.6.
- **Stale `tmp` override removed** — the previous `tmp` override is no longer needed; the parent packages now resolve a patched `tmp` on their own, so the pin was removed and verified clean against both npm audit and Snyk.

The existing `@grpc/grpc-js`, `serialize-javascript` and `uuid` overrides, and the `SNYK-JS-INFLIGHT-6095116` Snyk ignore, were each tested for staleness and all remain required.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ