### PR TITLE
PAE-1567: Pin auth stub images to explicit versions

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -134,7 +134,7 @@ services:
       retries: 3
 
   epr-re-ex-entra-stub:
-    image: defradigital/epr-re-ex-entra-stub:latest
+    image: defradigital/epr-re-ex-entra-stub:0.66.0
     ports:
       - 3010:3010
     environment:
@@ -146,7 +146,7 @@ services:
       retries: 3
 
   defra-id-stub:
-    image: defradigital/cdp-defra-id-stub:latest
+    image: defradigital/cdp-defra-id-stub:0.34.0
     ports:
       - '3200:3200'
     depends_on:


### PR DESCRIPTION
Ticket: [PAE-1567](https://eaflood.atlassian.net/browse/PAE-1567)
The functional test compose stack floated both auth stubs on `:latest`: `defradigital/epr-re-ex-entra-stub` and `defradigital/cdp-defra-id-stub`. When `cdp-defra-id-stub:latest` was republished as 0.35.0, it broke the org-linking auth flow and turned the suite red — even though admin auths via Entra, the stack still spins up the Defra ID stub.

Both images are now pinned to explicit tags so the suite no longer drifts when an upstream image is republished:

- `epr-re-ex-entra-stub` → `0.66.0` (current published version)
- `cdp-defra-id-stub` → `0.34.0` (last-good, ahead of the broken 0.35.0)

Renovate already enables the `docker-compose` manager, so it will track and bump these pinned tags like any other dependency — no config change needed.

Part of the wider effort (PAE-1567) to pin the auth stub images across the test and local-dev compose files.

[PAE-1567]: https://eaflood.atlassian.net/browse/PAE-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ