### PR TITLE
PAE-000: revert pin node version to 24.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "",
   "engines": {
-    "node": "<=24.16.0"
+    "node": ">=24.16.0 <25"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
Reverts DEFRA/epr-re-ex-admin-frontend-tests#244 — node pin no longer needed now undici is unified via overrides.