### PR TITLE
PAE-000: unpin alpine minor in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.17-alpine3.24
+FROM node:24.17-alpine
 
 ENV TZ="Europe/London"
 


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
stop pinning the alpine minor in the node base image (`node:24.17-alpine3.24` -> `node:24.17-alpine`). pinning the alpine minor couples node-patch availability to a specific alpine release (node 24.17 ships only on alpine 3.23/3.24, not 3.22), which blocks renovate from finding node updates and breaks docker builds. letting alpine float to the node image default avoids the variant lock.