### PR TITLE
PAE-000: pin node patch version in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.17-alpine
+FROM node:24.17.0-alpine
 
 ENV TZ="Europe/London"
 


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
pin the node patch in the base image (`node:24.17-alpine` -> `node:24.17.0-alpine`) so the node version is explicit and renovate-managed rather than silently floating patch releases. pairs with digest pinning (epr-re-ex-service#290) for fully reproducible, reviewable base-image updates.