### PR TITLE
PAE-1654: Update CSV journey assertions to unquoted numeric format

### DIFF
--- a/test/specs/ors.upload.e2e.js
+++ b/test/specs/ors.upload.e2e.js
@@ -100,7 +100,7 @@ describe('ORS upload flow @orsupload', () => {
       'attachment; filename="overseas-reprocessing-sites.csv"'
     )
     expect(csvDownload.body).toContain(
-      '"Org ID","Registration Number","Accreditation Number","ORS ID"'
+      'Org ID,Registration Number,Accreditation Number,ORS ID'
     )
     expect(csvDownload.body).toContain(String(orgId))
     expect(csvDownload.body).toContain(registrationNumber)
@@ -326,7 +326,7 @@ describe('ORS upload flow @orsupload', () => {
         'attachment; filename="overseas-reprocessing-sites.csv"'
       )
       expect(filteredCsvDownload.body).toContain(
-        '"Org ID","Registration Number","Accreditation Number","ORS ID"'
+        'Org ID,Registration Number,Accreditation Number,ORS ID'
       )
       expect(filteredCsvDownload.body).toContain(alphaRegistrationNumber)
       expect(filteredCsvDownload.body).toContain(betaRegistrationNumber)

--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -11,6 +11,44 @@ import LoginPage from 'page-objects/login.js'
 import Navigation from 'page-objects/navigation.js'
 import ReportSubmissionsPage from 'page-objects/report.submissions.page'
 
+/**
+ * Splits a single CSV row into fields, honouring fast-csv's default selective
+ * quoting so a quoted value containing a comma (e.g. an organisation name)
+ * stays one field.
+ * @param {string} row
+ * @returns {string[]}
+ */
+function parseCsvRow(row) {
+  const fields = []
+  let field = ''
+  let inQuotes = false
+
+  for (let i = 0; i < row.length; i++) {
+    const character = row[i]
+
+    if (inQuotes) {
+      if (character === '"' && row[i + 1] === '"') {
+        field += '"'
+        i++
+      } else if (character === '"') {
+        inQuotes = false
+      } else {
+        field += character
+      }
+    } else if (character === '"') {
+      inQuotes = true
+    } else if (character === ',') {
+      fields.push(field)
+      field = ''
+    } else {
+      field += character
+    }
+  }
+
+  fields.push(field)
+  return fields
+}
+
 describe('Report Submissions page', () => {
   let orgName
 
@@ -53,7 +91,7 @@ describe('Report Submissions page', () => {
     const rows = csv.body
       .split(/\r?\n/)
       .filter((line) => line.trim().length > 0)
-    const headerIndex = rows.findIndex((row) => row.startsWith('"Regulator"'))
+    const headerIndex = rows.findIndex((row) => row.startsWith('Regulator,'))
     await expect(headerIndex).toBeGreaterThanOrEqual(0)
     const dataRows = rows.slice(headerIndex + 1)
 
@@ -62,7 +100,7 @@ describe('Report Submissions page', () => {
     if (!orgRow) {
       throw new Error('Organisation row not found')
     }
-    const cols = /** @type {string} */ (orgRow).split('","')
+    const cols = parseCsvRow(/** @type {string} */ (orgRow))
     await expect(cols[12]).toBeTruthy()
     await expect(cols[13]).toBeTruthy()
     await expect(cols[15]).toBeTruthy()
@@ -79,7 +117,7 @@ describe('Report Submissions page', () => {
     const rows = csv.body
       .split(/\r?\n/)
       .filter((line) => line.trim().length > 0)
-    const headerIndex = rows.findIndex((row) => row.startsWith('"Regulator"'))
+    const headerIndex = rows.findIndex((row) => row.startsWith('Regulator,'))
     await expect(headerIndex).toBeGreaterThanOrEqual(0)
 
     const headerRow = rows[headerIndex]


### PR DESCRIPTION
Ticket: [PAE-1654](https://eaflood.atlassian.net/browse/PAE-1654)
The admin CSV exports now emit numeric columns as genuine unquoted numbers, using fast-csv's default selective quoting rather than quoting every cell. This updates the journey-test assertions for the report-submissions and ORS downloads to match the new format.

- ORS download — the expected header line drops the per-cell quotes.
- Report submissions — the header row is detected by its unquoted prefix, and data rows are parsed with quote-aware splitting so a quoted organisation name containing a comma stays a single field (faker can generate such names, so a naive comma split would be flaky).

Pairs with the service change in DEFRA/epr-re-ex-admin-frontend#445 and must merge alongside it so these assertions stay green on main.


[PAE-1654]: https://eaflood.atlassian.net/browse/PAE-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ