### PR TITLE
PAE-1556: fix system log difference selector by key text

### DIFF
--- a/test/page-objects/system.logs.page.js
+++ b/test/page-objects/system.logs.page.js
@@ -62,11 +62,12 @@ class SystemLogsPage extends Page {
     return userId.trim()
   }
 
+  // Reads the "Difference" JSON from the most recent system log result card.
+  // Matches the row by its key text rather than position, so it is unaffected
+  // by rows being added to or removed from the summary list.
   async jsonDifference() {
-    const difference = await $(
-      '#main-content div.govuk-summary-card dl.govuk-summary-list div.govuk-summary-list__row:nth-child(9) > dd > code'
-    )
-    return difference.getText()
+    const card = await $('#main-content div.govuk-summary-card')
+    return this.logCardField(card, 'Difference')
   }
 
   async noSystemLogsFound() {


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
select the difference summary-list row by its key text instead of a positional nth-child, so it is unaffected by rows being added to or removed from the system log card. fixes the recurring journey test breakage on the system logs spec.

[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ