### PR TITLE
PAE-1556: fix unsubmit confirmation selectors by class and text

### DIFF
--- a/test/page-objects/unsubmit.confirmation.page.js
+++ b/test/page-objects/unsubmit.confirmation.page.js
@@ -3,19 +3,19 @@ import { $ } from '@wdio/globals'
 
 class UnsubmitConfirmationPage extends Page {
   async getWarningText() {
-    return await $('#main-content > div > div > div > strong').getText()
+    return await $('.govuk-warning-text__text').getText()
   }
 
   async confirmUnsubmit() {
-    await $('#main-content > div > div > form > button').click()
+    await $('button=Yes, unsubmit this report').click()
   }
 
   async getSuccessMessage() {
-    return await $('#main-content > div > div > div > div > h1').getText()
+    return await $('.govuk-panel__title').getText()
   }
 
   async returnToRegistrationOverview() {
-    await $('#main-content > div > div > div > p:nth-child(5) > a').click()
+    await $('a=Back to registration overview').click()
   }
 }
 


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
replace brittle positional selectors on the unsubmit confirmation page with stable govuk component class hooks and visible text, so the journey test is unaffected by layout markup changes. fixes the recurring unsubmit journey test failure.

[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ