### PR TITLE
PAE-1662: Assert excluded from waste balance reason column in export e2e test

### DIFF
--- a/test/specs/wasterecordsexport.e2e.js
+++ b/test/specs/wasterecordsexport.e2e.js
@@ -36,6 +36,7 @@ describe('Waste records export page', () => {
       'Waste Record Type',
       'Submitted At',
       'Included in Waste Balance',
+      'Waste Balance Exclusion Reason',
       'Row ID'
     ]
 


### PR DESCRIPTION
Ticket: [PAE-1662](https://eaflood.atlassian.net/browse/PAE-1662)
- Add `Excluded from Waste Balance Reason` to the expected metadata header columns asserted in the waste records export e2e test

[PAE-1662]: https://eaflood.atlassian.net/browse/PAE-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ