### PR TITLE
PAE-000: track node lts via lts-alpine and caret engines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18.0-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+FROM node:lts-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 ENV TZ="Europe/London"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=24.18.0 <25"
+        "node": "^24.18.0"
       }
     },
     "node_modules/@axe-core/webdriverio": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "",
   "engines": {
-    "node": ">=24.18.0 <25"
+    "node": "^24.18.0"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
follows the shared preset change (epr-re-ex-service#297). use docker hub's `lts-alpine` tag (digest-pinned) so the base image tracks active lts automatically and never picks up a current/odd node line. switch engines to a single `^x.y.z` token — same `engine-strict` guardrail as `>=x <25` but it advances cleanly to the next lts.

- dockerfile: `node:24.18.0-alpine` -> `node:lts-alpine` (digest unchanged; lts is node 24 today)
- engines: `>=24.18.0 <25` -> `^24.18.0`