### PR TITLE
PAE-1662: Assert Waste Balance Tonnage column in export e2e test

### DIFF
--- a/test/specs/wasterecordsexport.e2e.js
+++ b/test/specs/wasterecordsexport.e2e.js
@@ -37,6 +37,7 @@ describe('Waste records export page', () => {
       'Submitted At',
       'Included in Waste Balance',
       'Waste Balance Exclusion Reason',
+      'Waste Balance Tonnage',
       'Row ID'
     ]
 


### PR DESCRIPTION
Ticket: [PAE-1662](https://eaflood.atlassian.net/browse/PAE-1662)
- Add `Waste Balance Tonnage` to expected metadata headers in waste records export e2e test

[PAE-1662]: https://eaflood.atlassian.net/browse/PAE-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ