### PR TITLE
PAE-1657: assert Unsubmit is hidden on a superseded submission

### DIFF
--- a/test/specs/registration.overview.submissions.e2e.js
+++ b/test/specs/registration.overview.submissions.e2e.js
@@ -163,6 +163,27 @@ describe('Registration overview - multiple submissions per period', function () 
       )
     }
 
+    // Submission 1 is now superseded by the later submitted submission 2, so
+    // its row offers View only: Unsubmit is hidden on a superseded submission
+    // (PAE-1657, admin-frontend #472). Submission 2, the current submission,
+    // still offers Unsubmit.
+    const supersededRow = findOrThrow(
+      quarterOneRows,
+      (row) => row.submission === '1',
+      'Quarter 1 superseded submission 1 row'
+    )
+    expect(supersededRow.links.map((link) => link.text)).toEqual(['View'])
+
+    const currentRow = findOrThrow(
+      quarterOneRows,
+      (row) => row.submission === '2',
+      'Quarter 1 current submission 2 row'
+    )
+    expect(currentRow.links.map((link) => link.text)).toEqual([
+      'View',
+      'Unsubmit'
+    ])
+
     // Opening a prior submission resolves that submission: the report view
     // heading names it.
     const firstSubmissionRowNumber =


### PR DESCRIPTION
Ticket: [PAE-1657](https://eaflood.atlassian.net/browse/PAE-1657)
## Description

The admin registration-overview suite proved multiple submissions per period are visible and reachable, but never asserted that Unsubmit is hidden on a superseded submission — the behaviour shipped in admin-frontend #472.

This adds that assertion to the existing @multipleSubmissions test, reusing the state it already seeds (two submitted submissions for one period), so no extra setup or seeding cost:

**Submission 1 (superseded)** — its row offers View only.
**Submission 2 (current)** — its row offers View and Unsubmit.
Asserting both rows in the same render isolates supersession as the cause: the same write-scoped user, same page load, and both rows already asserted submitted, so the only variable explaining the difference is isSuperseded. It's a genuine guard — pre-fix both rows carried Unsubmit, so it would fail on regression.

Not redundant with existing coverage — the other two unsubmit tests exercise different gate conditions and never create a second submission:

permissions.e2e.js — link hidden by lack of adminWrite scope.
organisations.e2e.js — link hidden by a status change after unsubmit.
This is the only e2e coverage of the superseded case (the equivalent component-level check lives in the admin-frontend repo's get.integration.test.js).

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1657]: https://eaflood.atlassian.net/browse/PAE-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ