### PR TITLE
PAE-1593: Enable summary-log row-states flag in journey compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -212,6 +212,12 @@ services:
       # resubmission (submission 2+) creation and closed-period marking on it,
       # which the multiple-submissions registration overview journey relies on.
       FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: ${FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS:-true}
+      # On in every deployed environment (and in epr-backend-journey-tests): the
+      # report-detail read derives from summary-log row states, whose repository
+      # is only registered when this flag is on. Without it, GET report detail
+      # 500s, so keep it on here to match deployed config.
+      FEATURE_FLAG_SUMMARY_LOG_ROW_STATES: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES:-true}
+      FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL:-true}
     ports:
       - '3001:3001'
     healthcheck:


### PR DESCRIPTION
Ticket: [PAE-1593](https://eaflood.atlassian.net/browse/PAE-1593)

## What

Set `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES` (and its `_BACKFILL` sibling) on the `epr-backend` service in `compose.yml`, defaulting to `true`, to match every deployed environment and the other journey composes.

## Why

The backend derives report detail from summary-log row states. Its row-state repository is only registered when `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES` is on. This compose never set the flag, so the journey backend booted with it off (default `false`, confirmed by `summaryLogRowStates=false` in the backend boot log), the repository was never registered, and reading report detail returned a 500 (`TypeError: Cannot read properties of undefined (reading 'findRowStatesForSummaryLog')`). That cascaded into the multiple-submissions registration-overview journey (`registration.overview.submissions.e2e.js`), whose seed step `POST .../submissions/2` failed with 500.

This is the same root cause and fix as epr-frontend-journey-tests [#448](https://github.com/DEFRA/epr-frontend-journey-tests/pull/448). Every deployed environment (prod, test, dev, perf-test) sets this flag to `true`, and `epr-backend-journey-tests/compose.yml` already sets it. This change brings the admin journey compose in line so its backend behaves like the deployed one.

No production behaviour changes: journey-test configuration only. The flag stays overridable via the environment, consistent with the other feature flags in this file.

[PAE-1593]: https://eaflood.atlassian.net/browse/PAE-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ