### PR TITLE
PAE-1738: Stop setting removed row-state feature flags

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -212,7 +212,6 @@ services:
       # resubmission (submission 2+) creation and closed-period marking on it,
       # which the multiple-submissions registration overview journey relies on.
       FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: ${FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS:-true}
-      FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL:-true}
     ports:
       - '3001:3001'
     healthcheck:

--- a/compose.yml
+++ b/compose.yml
@@ -212,11 +212,6 @@ services:
       # resubmission (submission 2+) creation and closed-period marking on it,
       # which the multiple-submissions registration overview journey relies on.
       FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: ${FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS:-true}
-      # On in every deployed environment (and in epr-backend-journey-tests): the
-      # report-detail read derives from summary-log row states, whose repository
-      # is only registered when this flag is on. Without it, GET report detail
-      # 500s, so keep it on here to match deployed config.
-      FEATURE_FLAG_SUMMARY_LOG_ROW_STATES: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES:-true}
       FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL:-true}
     ports:
       - '3001:3001'


### PR DESCRIPTION
Ticket: [PAE-1738](https://eaflood.atlassian.net/browse/PAE-1738)
## Summary

- Stops setting `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES` on the epr-backend container in compose — DEFRA/epr-backend#1509 removes the flag and makes row-state persistence (and repository registration) unconditional, so the env var is now ignored.
- Also stops setting `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL` (review feedback): the backfill flag has since been removed from epr-backend main as well, so it is equally ignored.
- Removes the comment explaining why the row-states flag had to be on; the constraint no longer exists.
- Safe to merge in either order relative to the backend changes: the backend's config ignores undeclared env vars.

## Changes

- `compose.yml` — drop the `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES` and `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL` environment entries and the stale comment


[PAE-1738]: https://eaflood.atlassian.net/browse/PAE-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
