### PR TITLE
PAE-1659: assert report-submissions CSV handles multiple submissions …

### DIFF
--- a/test/specs/registration.overview.submissions.e2e.js
+++ b/test/specs/registration.overview.submissions.e2e.js
@@ -7,20 +7,10 @@ import RegistrationOverviewPage from 'page-objects/registration.overview.page.js
 import ReportViewPage from 'page-objects/report.view.page.js'
 import UnsubmitConfirmationPage from 'page-objects/unsubmit.confirmation.page.js'
 import {
-  createLinkedOrganisation,
-  updateMigratedOrganisation,
-  linkDefraUser,
+  RESTATED_PERIOD,
   seedReportSubmission,
-  uploadAndSubmitSummaryLog,
-  waitForReportingPeriodStatus
+  seedRestatedClosedPeriod
 } from '../support/apicalls.js'
-
-// Must match the REGISTRATION_NUMBER meta cell inside the fixture spreadsheet.
-const REGISTRATION_NUMBER = 'R25SR500040912PA'
-// The fixture restates Q1 2026, so the seeded submitted report must be for
-// that period (registered-only registrations report quarterly).
-const CMA_FIXTURE = 'test/fixtures/reprocessor-output-regonly-cma.xlsx'
-const PERIOD = { year: 2026, cadence: 'quarterly', period: 1 }
 
 const isQuarterOne2026 = (row) =>
   row.period === 'Quarter 1' && row.due.startsWith('2026')
@@ -49,52 +39,13 @@ describe('Registration overview - multiple submissions per period', function () 
   })
 
   it('lists every submission for a period as its own reachable row, with submission numbers on view and unsubmit pages @organisations @multipleSubmissions', async () => {
-    // Registered-only reprocessor whose registration matches the fixture.
-    const linkedOrganisation = await createLinkedOrganisation([
-      {
-        material: 'Paper or board (R3)',
-        wasteProcessingType: 'Reprocessor',
-        withoutAccreditation: true
-      }
-    ])
-    const migrated = await updateMigratedOrganisation(
-      linkedOrganisation.refNo,
-      [
-        {
-          regNumber: REGISTRATION_NUMBER,
-          status: 'approved',
-          reprocessingType: 'output'
-        }
-      ]
-    )
-    const registrationId = migrated.registrations[0].id
-    const { defraAuthHeader } = await linkDefraUser(linkedOrganisation.refNo)
-
-    // Close Q1 2026 with a submitted report, then restate it via a summary
-    // log so the backend flags the period as requiring resubmission.
-    await seedReportSubmission(
-      linkedOrganisation.refNo,
-      registrationId,
-      defraAuthHeader,
-      { ...PERIOD, submissionNumber: 1 }
-    )
-    await uploadAndSubmitSummaryLog(
-      linkedOrganisation.refNo,
-      registrationId,
-      defraAuthHeader,
-      CMA_FIXTURE
-    )
-    await waitForReportingPeriodStatus(
-      linkedOrganisation.refNo,
-      registrationId,
-      defraAuthHeader,
-      'requires_resubmission'
-    )
+    // A registered-only reprocessor whose Q1 2026 is closed by a submitted
+    // report and then restated, so the backend flags it requiring resubmission.
+    const { refNo, companyName, registrationId, defraAuthHeader } =
+      await seedRestatedClosedPeriod()
 
     await OrganisationsPage.open()
-    await OrganisationsPage.searchFor(
-      linkedOrganisation.organisation.companyName
-    )
+    await OrganisationsPage.searchFor(companyName)
     await OrganisationsPage.viewLink(1)
     await OrganisationOverviewPage.viewRegistrationLink(1)
 
@@ -137,12 +88,10 @@ describe('Registration overview - multiple submissions per period', function () 
 
     // Resubmit via the API: the period now holds two submitted submissions,
     // each with its own row and its own View link.
-    await seedReportSubmission(
-      linkedOrganisation.refNo,
-      registrationId,
-      defraAuthHeader,
-      { ...PERIOD, submissionNumber: 2 }
-    )
+    await seedReportSubmission(refNo, registrationId, defraAuthHeader, {
+      ...RESTATED_PERIOD,
+      submissionNumber: 2
+    })
     await browser.refresh()
 
     reportsData = await RegistrationOverviewPage.getReportsTableData()

--- a/test/specs/reportsubmissions.e2e.js
+++ b/test/specs/reportsubmissions.e2e.js
@@ -10,44 +10,7 @@ import {
 import LoginPage from 'page-objects/login.js'
 import Navigation from 'page-objects/navigation.js'
 import ReportSubmissionsPage from 'page-objects/report.submissions.page'
-
-/**
- * Splits a single CSV row into fields, honouring fast-csv's default selective
- * quoting so a quoted value containing a comma (e.g. an organisation name)
- * stays one field.
- * @param {string} row
- * @returns {string[]}
- */
-function parseCsvRow(row) {
-  const fields = []
-  let field = ''
-  let inQuotes = false
-
-  for (let i = 0; i < row.length; i++) {
-    const character = row[i]
-
-    if (inQuotes) {
-      if (character === '"' && row[i + 1] === '"') {
-        field += '"'
-        i++
-      } else if (character === '"') {
-        inQuotes = false
-      } else {
-        field += character
-      }
-    } else if (character === '"') {
-      inQuotes = true
-    } else if (character === ',') {
-      fields.push(field)
-      field = ''
-    } else {
-      field += character
-    }
-  }
-
-  fields.push(field)
-  return fields
-}
+import { parseCsvRow } from '../support/csv.js'
 
 describe('Report Submissions page', () => {
   let orgName

--- a/test/specs/reportsubmissions.multiplesubmissions.e2e.js
+++ b/test/specs/reportsubmissions.multiplesubmissions.e2e.js
@@ -1,0 +1,118 @@
+import { browser, expect } from '@wdio/globals'
+
+import LoginPage from 'page-objects/login.js'
+import ReportSubmissionsPage from 'page-objects/report.submissions.page'
+import { parseCsvRows } from '../support/csv.js'
+import {
+  RESTATED_PERIOD,
+  seedDraftSubmission,
+  seedRestatedClosedPeriod,
+  submitSeededDraft
+} from '../support/apicalls.js'
+
+// The admin table renders the same period as 'Quarter 1', so this label is
+// specific to the CSV.
+const PERIOD_LABEL = 'Q1 2026'
+
+// Distinct per submission, so a row can be tied back to the report it came from.
+const SUBMISSION_1_TONNAGE = 10
+const SUBMISSION_2_TONNAGE = 20
+
+const SUBMISSION_2 = { ...RESTATED_PERIOD, submissionNumber: 2 }
+
+/**
+ * Throws rather than returning the status: a failed download would otherwise
+ * surface as an empty row list, failing a row-count assertion and pointing at
+ * the wrong cause.
+ *
+ * Matches on organisation name, not registration number: every org seeded by
+ * seedRestatedClosedPeriod shares the fixture's registration number, so that
+ * would also match orgs left by previous runs. The faker name's random suffix
+ * makes it the only unique discriminator.
+ */
+async function downloadPeriodRows(companyName) {
+  await ReportSubmissionsPage.open()
+  const csv = await ReportSubmissionsPage.fetchCsv()
+
+  if (csv.status !== 200) {
+    throw new Error(`Report submissions CSV download failed: ${csv.status}`)
+  }
+
+  return parseCsvRows(csv.body).filter(
+    (row) =>
+      row['Organisation name'] === companyName &&
+      row['Report Period'] === PERIOD_LABEL
+  )
+}
+
+// Function (not arrow) so this.timeout is reachable: the summary-log pipeline
+// (upload, scan, async validation and submission) needs longer than the
+// default per-test minute.
+describe('Report submissions CSV - multiple submissions per period', function () {
+  this.timeout(3 * 60 * 1000)
+
+  before(async () => {
+    await browser.deleteCookies()
+    await LoginPage.open()
+    await LoginPage.enterCredentials('ea@test.gov.uk', 'pass')
+    await LoginPage.submitCredentials()
+  })
+
+  it('exports one row per submitted report, and an in-flight correction neither adds a row nor blanks the submitted figures @reportsubmissions @multipleSubmissions', async () => {
+    const { refNo, companyName, registrationId, defraAuthHeader } =
+      await seedRestatedClosedPeriod({ tonnageRecycled: SUBMISSION_1_TONNAGE })
+
+    const afterFirstSubmission = await downloadPeriodRows(companyName)
+    expect(afterFirstSubmission).toHaveLength(1)
+    expect(afterFirstSubmission[0]['Submission Number']).toEqual('1')
+    expect(afterFirstSubmission[0]['Tonnage recycled']).toEqual(
+      String(SUBMISSION_1_TONNAGE)
+    )
+    // Only asserted non-empty: this is the authenticated user's name, so a
+    // literal would pin the auth stub's fixture identity.
+    expect(afterFirstSubmission[0]['Submitted By']).not.toEqual('')
+
+    const submittedDate = afterFirstSubmission[0]['Submitted Date']
+    expect(submittedDate).not.toEqual('')
+
+    const version = await seedDraftSubmission(
+      refNo,
+      registrationId,
+      defraAuthHeader,
+      SUBMISSION_2,
+      { tonnageRecycled: SUBMISSION_2_TONNAGE, tonnageNotRecycled: 0 }
+    )
+
+    const whileDraftInFlight = await downloadPeriodRows(companyName)
+    expect(whileDraftInFlight).toHaveLength(1)
+    expect(whileDraftInFlight[0]['Submission Number']).toEqual('1')
+    expect(whileDraftInFlight[0]['Tonnage recycled']).toEqual(
+      String(SUBMISSION_1_TONNAGE)
+    )
+    expect(whileDraftInFlight[0]['Submitted Date']).toEqual(submittedDate)
+
+    await submitSeededDraft(
+      refNo,
+      registrationId,
+      defraAuthHeader,
+      SUBMISSION_2,
+      version
+    )
+
+    const afterResubmission = await downloadPeriodRows(companyName)
+    expect(afterResubmission).toHaveLength(2)
+    expect(afterResubmission.map((row) => row['Submission Number'])).toEqual([
+      '1',
+      '2'
+    ])
+    expect(afterResubmission.map((row) => row['Tonnage recycled'])).toEqual([
+      String(SUBMISSION_1_TONNAGE),
+      String(SUBMISSION_2_TONNAGE)
+    ])
+    // Each row carries its own submission's details, not the period's latest.
+    for (const row of afterResubmission) {
+      expect(row['Submitted By']).not.toEqual('')
+      expect(row['Submitted Date']).not.toEqual('')
+    }
+  })
+})

--- a/test/support/apicalls.js
+++ b/test/support/apicalls.js
@@ -307,11 +307,84 @@ export async function linkDefraUser(refNo) {
 // submissionNumber. Submission numbers above 1 are resubmissions: the backend
 // only permits them once the period's latest submitted report is marked as
 // requiring resubmission (see uploadAndSubmitSummaryLog).
-export async function seedReportSubmission(
+// Must match the REGISTRATION_NUMBER meta cell inside the fixture spreadsheet.
+const RESTATED_REGISTRATION_NUMBER = 'R25SR500040912PA'
+const RESTATED_CMA_FIXTURE = 'test/fixtures/reprocessor-output-regonly-cma.xlsx'
+// The period the CMA fixture restates. Consumers render it differently
+// ('Q1 2026' in the CSV, 'Quarter 1' in the admin table), so labels live with
+// the spec that reads them.
+export const RESTATED_PERIOD = { year: 2026, cadence: 'quarterly', period: 1 }
+
+/**
+ * Seeds a registered-only reprocessor whose Q1 2026 is submitted, then restated
+ * by a summary log so the period is flagged requires_resubmission.
+ *
+ * That flag is the precondition for creating submission 2 at all, and there is
+ * no endpoint for it: the backend sets it as a side effect of submitting the
+ * summary log, which is why a real fixture is uploaded here.
+ *
+ * @param {{ tonnageRecycled?: number }} [options]
+ * @returns {Promise<{ refNo: string, companyName: string, registrationId: string, defraAuthHeader: Record<string, string> }>}
+ */
+export async function seedRestatedClosedPeriod({ tonnageRecycled = 100 } = {}) {
+  const linkedOrganisation = await createLinkedOrganisation([
+    {
+      material: 'Paper or board (R3)',
+      wasteProcessingType: 'Reprocessor',
+      withoutAccreditation: true
+    }
+  ])
+  const refNo = linkedOrganisation.refNo
+  const companyName = linkedOrganisation.organisation.companyName
+
+  const migrated = await updateMigratedOrganisation(refNo, [
+    {
+      regNumber: RESTATED_REGISTRATION_NUMBER,
+      status: 'approved',
+      reprocessingType: 'output'
+    }
+  ])
+  const registrationId = migrated.registrations[0].id
+  const { defraAuthHeader } = await linkDefraUser(refNo)
+
+  await seedReportSubmission(
+    refNo,
+    registrationId,
+    defraAuthHeader,
+    { ...RESTATED_PERIOD, submissionNumber: 1 },
+    { tonnageRecycled, tonnageNotRecycled: 0 }
+  )
+  await uploadAndSubmitSummaryLog(
+    refNo,
+    registrationId,
+    defraAuthHeader,
+    RESTATED_CMA_FIXTURE
+  )
+  await waitForReportingPeriodStatus(
+    refNo,
+    registrationId,
+    defraAuthHeader,
+    'requires_resubmission'
+  )
+
+  return { refNo, companyName, registrationId, defraAuthHeader }
+}
+
+const submissionPath = (
+  refNo,
+  registrationId,
+  { year, cadence, period, submissionNumber }
+) =>
+  `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
+
+// Creates a submission and leaves it in_progress, returning the version the
+// next transition needs. An in-flight draft is a state under test in its own
+// right: it must not disturb what the period has already submitted.
+export async function seedDraftSubmission(
   refNo,
   registrationId,
   defraAuthHeader,
-  { year, cadence, period, submissionNumber },
+  periodSubmission,
   // Deliberately narrower than createSubmittedReport's patch: prnRevenue and
   // freeTonnage are optional PRN fields that only apply to accredited
   // registrations, and this helper seeds registered-only ones.
@@ -319,22 +392,30 @@ export async function seedReportSubmission(
 ) {
   const baseAPI = new BaseAPI()
   const jsonHeaders = { ...defraAuthHeader, 'content-type': 'application/json' }
-  const basePath = `/v1/organisations/${refNo}/registrations/${registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`
+  const basePath = submissionPath(refNo, registrationId, periodSubmission)
 
   const createResponse = await baseAPI.post(basePath, '', defraAuthHeader)
   await assertSuccessResponse(createResponse, `POST ${basePath}`)
 
-  let patchResponse = await baseAPI.patch(
-    basePath,
-    JSON.stringify(patchFields),
-    jsonHeaders
-  )
-  patchResponse = await assertSuccessResponse(
-    patchResponse,
+  const patchResponse = await assertSuccessResponse(
+    await baseAPI.patch(basePath, JSON.stringify(patchFields), jsonHeaders),
     `PATCH ${basePath}`
   )
 
-  let version = patchResponse.version
+  return patchResponse.version
+}
+
+// Drives an in_progress submission through ready_to_submit → submitted.
+export async function submitSeededDraft(
+  refNo,
+  registrationId,
+  defraAuthHeader,
+  periodSubmission,
+  version
+) {
+  const baseAPI = new BaseAPI()
+  const jsonHeaders = { ...defraAuthHeader, 'content-type': 'application/json' }
+  const basePath = submissionPath(refNo, registrationId, periodSubmission)
 
   const readyResponse = await baseAPI.post(
     `${basePath}/status`,
@@ -342,18 +423,40 @@ export async function seedReportSubmission(
     jsonHeaders
   )
   await assertSuccessResponse(readyResponse, `POST ${basePath}/status`)
-  version += 1
 
   const submitResponse = await baseAPI.post(
     `${basePath}/status`,
     JSON.stringify({
       status: 'submitted',
-      version,
+      version: version + 1,
       submissionDeclaredBy: 'Test User'
     }),
     jsonHeaders
   )
   await assertSuccessResponse(submitResponse, `POST ${basePath}/status`)
+}
+
+export async function seedReportSubmission(
+  refNo,
+  registrationId,
+  defraAuthHeader,
+  periodSubmission,
+  patchFields = { tonnageRecycled: 100, tonnageNotRecycled: 0 }
+) {
+  const version = await seedDraftSubmission(
+    refNo,
+    registrationId,
+    defraAuthHeader,
+    periodSubmission,
+    patchFields
+  )
+  await submitSeededDraft(
+    refNo,
+    registrationId,
+    defraAuthHeader,
+    periodSubmission,
+    version
+  )
 }
 
 const SUMMARY_LOG_FAILURE_STATUSES = [

--- a/test/support/csv.js
+++ b/test/support/csv.js
@@ -1,0 +1,64 @@
+/**
+ * Splits a single CSV row into fields, honouring fast-csv's default selective
+ * quoting so a quoted value containing a comma (e.g. an organisation name)
+ * stays one field.
+ * @param {string} row
+ * @returns {string[]}
+ */
+export function parseCsvRow(row) {
+  const fields = []
+  let field = ''
+  let inQuotes = false
+
+  for (let i = 0; i < row.length; i++) {
+    const character = row[i]
+
+    if (inQuotes) {
+      if (character === '"' && row[i + 1] === '"') {
+        field += '"'
+        i++
+      } else if (character === '"') {
+        inQuotes = false
+      } else {
+        field += character
+      }
+    } else if (character === '"') {
+      inQuotes = true
+    } else if (character === ',') {
+      fields.push(field)
+      field = ''
+    } else {
+      field += character
+    }
+  }
+
+  fields.push(field)
+  return fields
+}
+
+/**
+ * Parses a downloaded report CSV into one record per data row, keyed by column
+ * name so that an inserted column relocates a value rather than silently
+ * retargeting an assertion onto its neighbour.
+ *
+ * The body opens with a title/generated-at preamble, so the header is located
+ * by its first column rather than assumed to be line one.
+ *
+ * @param {string} body
+ * @returns {Record<string, string>[]}
+ */
+export function parseCsvRows(body) {
+  const lines = body.split(/\r?\n/).filter((line) => line.trim().length > 0)
+  const headerIndex = lines.findIndex((line) => line.startsWith('Regulator,'))
+
+  if (headerIndex === -1) {
+    throw new Error('CSV header row not found')
+  }
+
+  const names = parseCsvRow(lines[headerIndex])
+
+  return lines.slice(headerIndex + 1).map((line) => {
+    const values = parseCsvRow(line)
+    return Object.fromEntries(names.map((name, index) => [name, values[index]]))
+  })
+}


### PR DESCRIPTION
Ticket: [PAE-1659](https://eaflood.atlassian.net/browse/PAE-1659)

## Description

## What

Adds a journey test asserting the regulator **Report submissions** CSV copes with multiple
submissions per period (PAE-1659), plus the supporting test-infrastructure changes.

## Why

PAE-1659's logic is already covered twice — `report-submissions.test.js` (all five ACs) and the
admin frontend's `controller.post.test.js` (the CSV rendering and the new `Submission Number`
column). Neither covers the **seam between them**: the backend tests never build a CSV, and the
frontend's unit tests mock `fetchJsonFromBackend` and assert against a hand-built row object.

Nothing proved the real backend's `submissionNumber` survives Mongo → feed → HTTP → CSV mapper →
downloaded file. That's the only thing this test uniquely owns.

The defect is also **temporal** — the export was wrong *while a correction was in flight*, then
righted itself — so it can't be caught by a single snapshot. The test watches one period across a
state transition.

## What the test does

One organisation, one period (Q1 2026), three downloads of the real CSV through an authenticated
browser session:

| Stage | State | Asserted |
|---|---|---|
| 1 | submission 1 submitted | 1 row, `Submission Number` = `1`, `Tonnage recycled` = `10` |
| 2 | submission 2 created, left `in_progress` | still **1** row, unchanged — the draft adds no row and blanks nothing |
| 3 | submission 2 submitted | **2** rows, numbers `1` then `2` ascending, each with its own figures (`10`, `20`) |

Stage 2 is the ticket: the old export took the period's *current* report, which mid-correction is an
empty draft, so a period showing full figures went blank.

The tonnages differ per submission on purpose — it's what ties each row back to the report it came
from rather than the period's latest duplicated twice.

## Supporting changes

Reviewers will notice this touches two existing specs. Both are duplication removal, not behaviour
change:

- **`apicalls.js`** — adds `seedDraftSubmission` / `submitSeededDraft` (an in-flight draft is a
  state under test in its own right); `seedReportSubmission` now composes from them rather than
  repeating the sequence. Adds `seedRestatedClosedPeriod` beside `createSubmittedReport`, the
  scenario builder it mirrors.
- **`registration.overview.submissions.e2e.js`** — was duplicating the restated-period seed and its
  constants verbatim. Now consumes the shared one, so the CMA fixture coupling
  (`R25SR500040912PA` must match the spreadsheet's meta cell) lives in **one** place.
- **`csv.js`** (new) — parses a downloaded CSV keyed by **column name**. `parseCsvRow` is the
  existing implementation relocated out of `reportsubmissions.e2e.js`, which now imports it; only
  `parseCsvRows` is new.

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1659]: https://eaflood.atlassian.net/browse/PAE-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ