### PR TITLE
PAE-000: require curly braces around control statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default [
   },
   {
     rules: {
+      curly: ['error', 'all'],
       camelcase: [
         'error',
         {


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
adds eslint `curly: ['error', 'all']` rule to require braces around all if/else/for/while bodies, catching before commit what sonarqube flags.